### PR TITLE
Deal with Windows srand issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ sudo apt install g++-9
 
 If you would rather use `clang`, use `make clang`.
 
+QUANTAS exhibits unintended behavior with the Windows implementation of \<cstdlib>; see disclaimer [below](#visual-studio).
+
 #### Basic Usage
 To use the simulator, first clone the repository. Once cloned, you need to configure the simulated algorithm for QUANTAS to run and an input file for the algorithm to use. QUANTAS comes with several example algorithms and input files. They are listed in the `makefile` in the root directory. Uncomment the required algorithm and input file, for example:
  
@@ -38,7 +40,7 @@ runs the compiled simulation with the speicifed input file.
        
 ```sh
 make debug
-````
+```
 compiles the simulator for debugging.
 
 
@@ -48,6 +50,8 @@ make clang
 ```
 
 #### Visual Studio
+
+**Warning:** Running this simulator on Windows will result in deterministic behavior where randomness is expected, due to `srand` exhibiting non-standard behavior and only seeding the random values for a single thread upon invocation. (This behavior can appear even when using a Windows build of g++ as the compiler.) Use at your own risk.
 
 To use our simulator with the Visual Studio editor takes additional steps.
 First, you'll need to create an empty solution.


### PR DESCRIPTION
Warn of weird behavior of `srand` on Windows that results in deterministic, predictable, understandable results (always a bad thing.)

I think that that professor just asked for documentation of the problem rather than actual code, given that it's just a weird anomaly in one specific execution environment, but this also wouldn't be hard to fix - there are 13 calls to `rand()` in the codebase and they could be replaced with modern C++ `random_device` stuff (which is also already used in some places.) Strictly speaking, `rand()` is described as "not thread-safe" in the [Linux documentation for it](https://linux.die.net/man/3/srand) too.

Like I said, I worry about calling `srand` at the beginning of every thread because I imagine it could be called in multiple threads concurrently and seed them with the same value which would result in them exhibiting the same behavior as each other where that is not expected. Or not. Idk.