### PR TITLE
Improve random number generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ sudo apt install g++-9
 
 If you would rather use `clang`, use `make clang`.
 
-QUANTAS exhibits unintended behavior with the Windows implementation of \<cstdlib>; see disclaimer [below](#visual-studio).
-
 #### Basic Usage
 To use the simulator, first clone the repository. Once cloned, you need to configure the simulated algorithm for QUANTAS to run and an input file for the algorithm to use. QUANTAS comes with several example algorithms and input files. They are listed in the `makefile` in the root directory. Uncomment the required algorithm and input file, for example:
  
@@ -50,8 +48,6 @@ make clang
 ```
 
 #### Visual Studio
-
-**Warning:** Running this simulator on Windows will result in deterministic behavior where randomness is expected, due to `srand` exhibiting non-standard behavior and only seeding the random values for a single thread upon invocation. (This behavior can appear even when using a Windows build of g++ as the compiler.) Use at your own risk.
 
 To use our simulator with the Visual Studio editor takes additional steps.
 First, you'll need to create an empty solution.

--- a/makefile
+++ b/makefile
@@ -91,7 +91,12 @@ $(PROJECT_DIR)/%.o: $(PROJECT_DIR)/%.c
 run: all
 	./$(EXE) $(INPUTFILE)
 
-TESTS = test_Example test_Bitcoin test_Ethereum test_PBFT test_Raft test_SmartShards test_LinearChord test_Kademlia test_AltBit test_StableDataLink test_ChangRoberts test_Dynamic test_KPT test_KSM
+# in the future this could be generalized to go through every file in "Tests"
+rand_test: $(PROJECT_DIR)/Tests/randtest.cpp $(PROJECT_DIR)/Common/Distribution.cpp
+	$(CXX) $^ -o $@.exe
+	./$@.exe
+
+TESTS = rand_test test_Example test_Bitcoin test_Ethereum test_PBFT test_Raft test_SmartShards test_LinearChord test_Kademlia test_AltBit test_StableDataLink test_ChangRoberts test_Dynamic test_KPT test_KSM
 
 ############################### Compile and run all tests - uses a wild card.
 test: $(TESTS)

--- a/makefile
+++ b/makefile
@@ -95,6 +95,7 @@ run: all
 rand_test: $(PROJECT_DIR)/Tests/randtest.cpp $(PROJECT_DIR)/Common/Distribution.cpp
 	$(CXX) $^ -o $@.exe
 	./$@.exe
+	@$(RM) $@.exe
 
 TESTS = rand_test test_Example test_Bitcoin test_Ethereum test_PBFT test_Raft test_SmartShards test_LinearChord test_Kademlia test_AltBit test_StableDataLink test_ChangRoberts test_Dynamic test_KPT test_KSM
 
@@ -125,6 +126,10 @@ clean:
 	@$(RM) $(PROJECT_DIR)/*.tmp
 	@$(RM) $(PROJECT_DIR)/*.o
 	@$(RM) $(PROJECT_DIR)/*.d
+	@$(RM) $(PROJECT_DIR)/Common/*.gch
+	@$(RM) $(PROJECT_DIR)/Common/*.tmp
+	@$(RM) $(PROJECT_DIR)/Common/*.o
+	@$(RM) $(PROJECT_DIR)/Common/*.d
 	@$(RM) $(PROJECT_DIR)/$(ALGFILE)/*.gch
 	@$(RM) $(PROJECT_DIR)/$(ALGFILE)/*.tmp
 	@$(RM) $(PROJECT_DIR)/$(ALGFILE)/*.o
@@ -133,5 +138,6 @@ clean:
 	@$(RM) quantas_test/*.tmp
 	@$(RM) quantas_test/*.o
 	@$(RM) quantas_test/*.d
+	@$(RM) rand_test.exe
 
 -include $(OBJS:.o=.d)

--- a/makefile
+++ b/makefile
@@ -62,7 +62,7 @@ CXXFLAGS = -pthread -include $(PROJECT_DIR)/$(ALGFILE)/$(ALGFILE).hpp
 CXX := g++-9
 
 EXE := quantas.exe
-OBJS = $(PROJECT_DIR)/main.o $(PROJECT_DIR)/$(ALGFILE)/$(ALGFILE).o
+OBJS = $(PROJECT_DIR)/main.o $(PROJECT_DIR)/$(ALGFILE)/$(ALGFILE).o $(PROJECT_DIR)/Common/Distribution.o
 
 
 # extra debug and release flags
@@ -105,7 +105,8 @@ test_%:
 	@echo Testing $(ALGFILE)
 	@$(CXX) $(CXXFLAGS) -c -o quantas/main.o quantas/main.cpp
 	@$(CXX) $(CXXFLAGS) -c -o quantas/$(ALGFILE)/$(ALGFILE).o quantas/$(ALGFILE)/$(ALGFILE).cpp
-	@$(CXX) $(CXXFLAGS)  quantas/main.o quantas/$(ALGFILE)/$(ALGFILE).o -o $(EXE)
+	@$(CXX) $(CXXFLAGS) -c -o quantas/Common/Distribution.o quantas/Common/Distribution.cpp
+	@$(CXX) $(CXXFLAGS)  quantas/main.o quantas/$(ALGFILE)/$(ALGFILE).o quantas/Common/Distribution.o -o $(EXE)
 	@./$(EXE) quantas/$(ALGFILE)/$*Input.json
 	@$(RM) quantas/$(ALGFILE)/*.o
 	@echo $(ALGFILE) successful

--- a/quantas/AltBitPeer/AltBitPeer.cpp
+++ b/quantas/AltBitPeer/AltBitPeer.cpp
@@ -53,7 +53,7 @@ namespace quantas {
 				Packet<AltBitMessage> packet = popInStream();
 				long source = packet.sourceId();
 				AltBitMessage message = packet.getMessage();
-				if (rand() % messageLossDen < messageLossNum) { // used for message loss
+				if (randMod(messageLossDen) < messageLossNum) { // used for message loss
 					continue;
 				}
 				if (message.action == "ack") {

--- a/quantas/BitcoinPeer/BitcoinPeer.cpp
+++ b/quantas/BitcoinPeer/BitcoinPeer.cpp
@@ -91,7 +91,7 @@ namespace quantas {
 	}
 
 	bool BitcoinPeer::guardSubmitTrans() {
-		return rand() % submitRate == 0;
+		return randMod(submitRate) == 0;
 	}
 
 	void BitcoinPeer::submitTrans() {
@@ -104,7 +104,7 @@ namespace quantas {
 	}
 
 	bool BitcoinPeer::guardMineBlock() {
-		return rand() % mineRate == 0;
+		return randMod(mineRate) == 0;
 	}
 
 	void BitcoinPeer::mineBlock() {

--- a/quantas/Common/Distribution.cpp
+++ b/quantas/Common/Distribution.cpp
@@ -7,13 +7,13 @@ namespace quantas
     thread_local default_random_engine RANDOM_GENERATOR =
         default_random_engine(static_cast<int>(time(nullptr))+_hasher(std::this_thread::get_id()));
     
-    int uniformInt(const int &min, const int &max)
+    int uniformInt(const int min, const int max)
     {
         std::uniform_int_distribution<int> distribution(min, max);
         return distribution(RANDOM_GENERATOR);
     }
 
-    int randMod(const int &exclusiveMax)
+    int randMod(const int exclusiveMax)
     {
         std::uniform_int_distribution<int> distribution(0, exclusiveMax - 1);
         return distribution(RANDOM_GENERATOR);

--- a/quantas/Common/Distribution.cpp
+++ b/quantas/Common/Distribution.cpp
@@ -1,0 +1,21 @@
+#include "Distribution.hpp"
+
+namespace quantas
+{
+    std::hash<std::thread::id> _hasher;
+    
+    thread_local default_random_engine RANDOM_GENERATOR =
+        default_random_engine(static_cast<int>(time(nullptr))+_hasher(std::this_thread::get_id()));
+    
+    int uniformInt(const int &min, const int &max)
+    {
+        std::uniform_int_distribution<int> distribution(min, max);
+        return distribution(RANDOM_GENERATOR);
+    }
+
+    int randMod(const int &exclusiveMax)
+    {
+        std::uniform_int_distribution<int> distribution(0, exclusiveMax - 1);
+        return distribution(RANDOM_GENERATOR);
+    }
+}

--- a/quantas/Common/Distribution.hpp
+++ b/quantas/Common/Distribution.hpp
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License along with QUA
 #include <random>
 #include <iostream>
 #include <thread>
-#include "./../Common/Peer.hpp"
 #include "Json.hpp"
 
 
@@ -30,25 +29,18 @@ namespace quantas{
     using nlohmann::json;
     using std::cerr;
 
-    std::hash<std::thread::id> _hasher;
-    // random number generator that will be created and seeded uniquely once in each thread
-    static thread_local default_random_engine RANDOM_GENERATOR =
-        default_random_engine(static_cast<int>(time(nullptr))+_hasher(std::this_thread::get_id()));
+    // random number generator that will be created and seeded uniquely once in
+    // each thread
+    extern thread_local default_random_engine RANDOM_GENERATOR;
 
     // convenience function for using the random number generator to get a
     // random int in the range [min, max]
-    int uniformInt(const int & min, const int & max) {
-        std::uniform_int_distribution<int> distribution(min, max);
-        return distribution(RANDOM_GENERATOR);
-    }
+    int uniformInt(const int & min, const int & max);
 
     // convenience function for using the random number generator to get a
     // random int in the range [0, exclusiveMax) (like calling rand() %
     // exclusiveMax, but thread-safe)
-    int randMod(const int & exclusiveMax) {
-        std::uniform_int_distribution<int> distribution(0, exclusiveMax-1);
-        return distribution(RANDOM_GENERATOR);
-    }
+    int randMod(const int & exclusiveMax);
 
     static const string                POISSON = "POISSON";
     static const string                UNIFORM = "UNIFORM";

--- a/quantas/Common/Distribution.hpp
+++ b/quantas/Common/Distribution.hpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License along with QUA
 #include <string>
 #include <random>
 #include <iostream>
+#include <thread>
 #include "./../Common/Peer.hpp"
 #include "Json.hpp"
 
@@ -25,8 +26,29 @@ namespace quantas{
     using std::string;
     using std::uniform_int_distribution;
     using std::poisson_distribution;
+    using std::default_random_engine;
     using nlohmann::json;
     using std::cerr;
+
+    std::hash<std::thread::id> _hasher;
+    // random number generator that will be created and seeded uniquely once in each thread
+    static thread_local default_random_engine RANDOM_GENERATOR =
+        default_random_engine(static_cast<int>(time(nullptr))+_hasher(std::this_thread::get_id()));
+
+    // convenience function for using the random number generator to get a
+    // random int in the range [min, max]
+    int uniformInt(const int & min, const int & max) {
+        std::uniform_int_distribution<int> distribution(min, max);
+        return distribution(RANDOM_GENERATOR);
+    }
+
+    // convenience function for using the random number generator to get a
+    // random int in the range [0, exclusiveMax) (like calling rand() %
+    // exclusiveMax, but thread-safe)
+    int randMod(const int & exclusiveMax) {
+        std::uniform_int_distribution<int> distribution(0, exclusiveMax-1);
+        return distribution(RANDOM_GENERATOR);
+    }
 
     static const string                POISSON = "POISSON";
     static const string                UNIFORM = "UNIFORM";
@@ -106,8 +128,7 @@ namespace quantas{
         int delay = -1;
         do {
             if (_type == UNIFORM) {
-                uniform_int_distribution<int> randomDistribution(_minDelay, _maxDelay);
-                delay = randomDistribution(RANDOM_GENERATOR);
+                delay = uniformInt(_minDelay, _maxDelay);
             }
             if (_type == POISSON) {
                 poisson_distribution<int> poissonDistribution(_avgDelay);

--- a/quantas/Common/Distribution.hpp
+++ b/quantas/Common/Distribution.hpp
@@ -35,12 +35,12 @@ namespace quantas{
 
     // convenience function for using the random number generator to get a
     // random int in the range [min, max]
-    int uniformInt(const int & min, const int & max);
+    int uniformInt(const int min, const int max);
 
     // convenience function for using the random number generator to get a
     // random int in the range [0, exclusiveMax) (like calling rand() %
     // exclusiveMax, but thread-safe)
-    int randMod(const int & exclusiveMax);
+    int randMod(const int exclusiveMax);
 
     static const string                POISSON = "POISSON";
     static const string                UNIFORM = "UNIFORM";

--- a/quantas/Common/Network.hpp
+++ b/quantas/Common/Network.hpp
@@ -28,7 +28,7 @@ You should have received a copy of the GNU General Public License along with QUA
 #include <memory>
 #include <thread>
 #include <algorithm>
-#include "./../Common/Peer.hpp"
+#include "Peer.hpp"
 #include "Distribution.hpp"
 
 namespace quantas{

--- a/quantas/Common/Network.hpp
+++ b/quantas/Common/Network.hpp
@@ -161,10 +161,7 @@ namespace quantas{
 
 	template<class type_msg, class peer_type>
 	void Network<type_msg, peer_type>::initNetwork(json topology, int lastRound) {
-	    std::random_device device;
-        std::mt19937 generator(device());
-	
-        for (int i = 0; i < _peers.size(); i++) {
+	    for (int i = 0; i < _peers.size(); i++) {
             delete _peers[i];
         }
         _peers = vector<Peer<type_msg>*>();
@@ -174,7 +171,7 @@ namespace quantas{
 		}
         if (topology["identifiers"] == "random") {
             // randomly shuffle nodes prior to setting up topology
-            std::shuffle(_peers.begin(),_peers.end(), generator);
+            std::shuffle(_peers.begin(),_peers.end(), RANDOM_GENERATOR);
         }
 
 	    if (topology["type"] == "complete") {

--- a/quantas/Common/NetworkInterface.hpp
+++ b/quantas/Common/NetworkInterface.hpp
@@ -226,11 +226,9 @@ namespace quantas{
     // Multicasts to a random sample of neighbors without repetition. Size of sample is also random.
     template <class message>
     void NetworkInterface<message>::randomMulticast(message msg) {
-        std::random_device device;
-        std::mt19937 generator(device());
-        std::uniform_int_distribution<int> distribution(0, _neighbors.size()); // interval: [0, n], where n is the amount of neighbors the particular node calling this function has
-        
-        int amountOfNeighbors = distribution(generator);
+       
+        // interval: [0, n], where n is the amount of neighbors the particular node calling this function has
+        int amountOfNeighbors = uniformInt(0, _neighbors.size());
                 
         std::vector<interfaceId> out;
         /* NEED TO USE C++17 OR NEWER FOR std::sample */
@@ -238,7 +236,7 @@ namespace quantas{
             _neighbors.begin(), _neighbors.end(),
             std::back_inserter(out),
             amountOfNeighbors,
-            generator
+            RANDOM_GENERATOR
         );
 
         for (auto it = out.begin(); it != out.end(); ++it) { // iterate through vector where the samples are written and send a message to all of them

--- a/quantas/Common/Packet.hpp
+++ b/quantas/Common/Packet.hpp
@@ -27,18 +27,14 @@ You should have received a copy of the GNU General Public License along with QUA
 #include "LogWriter.hpp"
 
 namespace quantas{
-
-    using std::default_random_engine;
+    
     using std::string;
-    using std::uniform_int_distribution;
     
     static const long NO_PEER_ID = -1;  // number used to indicate invalid peer id or un init peer id
 
     //
     //Base Message Class
     //
-
-    static default_random_engine RANDOM_GENERATOR = default_random_engine((int)time(nullptr));
 
     template<class message>
     class Packet{

--- a/quantas/Common/Packet.hpp
+++ b/quantas/Common/Packet.hpp
@@ -25,6 +25,7 @@ You should have received a copy of the GNU General Public License along with QUA
 #include <ctime>
 #include <random>
 #include "LogWriter.hpp"
+#include "Distribution.hpp"
 
 namespace quantas{
     

--- a/quantas/Common/Packet.hpp
+++ b/quantas/Common/Packet.hpp
@@ -121,8 +121,9 @@ namespace quantas{
 
     template <class message>
     void Packet<message>::setDelay(int maxDelay, int minDelay){
-        uniform_int_distribution<int> uniformDist(minDelay, maxDelay);
-        _delay = uniformDist(RANDOM_GENERATOR); // max is not included so delay 1 is next round delay 2 is one round waiting and then receve in the following round
+        // max is not included so delay 1 is next round delay 2 is one round
+        // waiting and then receve in the following round
+        _delay = uniformInt(minDelay, maxDelay);
     }
 
     template<class message>

--- a/quantas/DynamicPeer/DynamicPeer.cpp
+++ b/quantas/DynamicPeer/DynamicPeer.cpp
@@ -83,11 +83,7 @@ namespace quantas {
 	}
 
 	bool DynamicPeer::guardMineBlock() {
-		std::random_device device;
-		std::mt19937       generator(device());
-
-		std::uniform_int_distribution<int> distribution(1, mineRate);
-		return distribution(generator) == 1;
+		return uniformInt(1, mineRate) == 1;
 	}
 
 	void DynamicPeer::sendBlockChain() {

--- a/quantas/EthereumPeer/EthereumPeer.cpp
+++ b/quantas/EthereumPeer/EthereumPeer.cpp
@@ -111,7 +111,7 @@ namespace quantas {
 	}
 
 	bool EthereumPeer::guardSubmitTrans() {
-		return rand() % submitRate == 0;
+		return randMod(submitRate) == 0;
 	}
 
 	void EthereumPeer::submitTrans() {
@@ -124,7 +124,7 @@ namespace quantas {
 	}
 
 	bool EthereumPeer::guardMineBlock() {
-		return rand() % mineRate == 0;
+		return randMod(mineRate) == 0;
 	}
 
 	void EthereumPeer::mineBlock() {

--- a/quantas/KPTPeer/KPTPeer.cpp
+++ b/quantas/KPTPeer/KPTPeer.cpp
@@ -225,11 +225,7 @@ namespace quantas {
 	}
 
 	bool KPTPeer::guardMineBlock() {
-		std::random_device device;
-		std::mt19937       generator(device());
-
-		std::uniform_int_distribution<int> distribution(1, mineRate);
-		return distribution(generator) == 1;
+		return uniformInt(1, mineRate) == 1;
 	}
 
 	void KPTPeer::sendBlockChain() {

--- a/quantas/KSMPeer/KSMPeer.cpp
+++ b/quantas/KSMPeer/KSMPeer.cpp
@@ -260,11 +260,7 @@ namespace quantas {
 	}
 
 	bool KSMPeer::guardMineBlock() {
-		std::random_device device;
-		std::mt19937       generator(device());
-
-		std::uniform_int_distribution<int> distribution(1, mineRate); // interval: [1, mineRate]
-		return distribution(generator) == 1;
+		return uniformInt(1, mineRate) == 1;   // interval: [1, mineRate]
 	}
 
 	void KSMPeer::sendBlockChain() {

--- a/quantas/KademliaPeer/KademliaPeer.cpp
+++ b/quantas/KademliaPeer/KademliaPeer.cpp
@@ -51,7 +51,7 @@ namespace quantas {
 				}
 				for (int j = 0; j < groupedNeighbors.size(); j++) {
 					if (groupedNeighbors[j].size() > 0) {
-						int index = rand() % groupedNeighbors[j].size();
+						int index = randMod(groupedNeighbors[j].size());
 						fingers.insert(fingers.begin(), groupedNeighbors[j][index]);
 					}
 				}
@@ -77,7 +77,7 @@ namespace quantas {
 
 	void KademliaPeer::endOfRound(const vector<Peer<KademliaMessage>*>& _peers) {
 		const vector<KademliaPeer*> peers = reinterpret_cast<vector<KademliaPeer*> const&>(_peers);
-		peers[rand() % neighbors().size() + 1]->submitTrans(currentTransaction);
+		peers[randMod(neighbors().size()) + 1]->submitTrans(currentTransaction);
 		double satisfied = 0;
 		double hops = 0;
 		for (int i = 0; i < peers.size(); i++) {
@@ -111,7 +111,7 @@ namespace quantas {
 
 	void KademliaPeer::submitTrans(int tranID) {
 		KademliaMessage message;
-		message.reqId = rand() % (neighbors().size() + 1);
+		message.reqId = randMod(neighbors().size() + 1);
 		string binId = getBinaryId(message.reqId);
 		message.binId = binId;
 		message.action = "R";

--- a/quantas/LinearChordPeer/LinearChordPeer.cpp
+++ b/quantas/LinearChordPeer/LinearChordPeer.cpp
@@ -208,7 +208,7 @@ namespace quantas {
 	void LinearChordPeer::endOfRound(const vector<Peer<LinearChordMessage>*>& _peers) {
 		const vector<LinearChordPeer*> peers = reinterpret_cast<vector<LinearChordPeer*> const&>(_peers);
 		numberOfNodes = peers.size();
-		peers[rand() % numberOfNodes]->submitTrans(currentTransaction);
+		peers[randMod(numberOfNodes)]->submitTrans(currentTransaction);
 		double satisfied = 0;
 		double hops = 0;
 		for (int i = 0; i < peers.size(); i++) {
@@ -253,7 +253,7 @@ namespace quantas {
 
 	void LinearChordPeer::submitTrans(int tranID) {
 		LinearChordMessage message;
-		message.reqId = rand() % numberOfNodes;
+		message.reqId = randMod(numberOfNodes);
 		long reqId = message.reqId;
 		message.action = "R";
 		message.roundSubmitted = getRound();

--- a/quantas/RaftPeer/RaftPeer.cpp
+++ b/quantas/RaftPeer/RaftPeer.cpp
@@ -136,7 +136,7 @@ namespace quantas {
 	}
 
 	void RaftPeer::resetTimer() {
-		timeOutRound = (rand() % timeOutRandom) + timeOutSpacing + getRound();
+		timeOutRound = (randMod(timeOutRandom)) + timeOutSpacing + getRound();
 	}
 
 	void RaftPeer::sendMessage(long peer, RaftPeerMessage message) {

--- a/quantas/SmartShardsPeer/SmartShardsPeer.cpp
+++ b/quantas/SmartShardsPeer/SmartShardsPeer.cpp
@@ -101,7 +101,7 @@ namespace quantas {
 				peers[shardGrid[i][j]]->workingTrans[i] = 0;
 				peers[shardGrid[i][j]]->alive = true;
 			}
-			int leader = rand() % shardGrid[i].size();
+			int leader = randMod(shardGrid[i].size());
 			peers[shardGrid[i][leader]]->shards[i] = true;
 			peers[shardGrid[i][leader]]->submitTrans(i);
 		}
@@ -154,7 +154,7 @@ namespace quantas {
 					numberOfJoinRequests = 1;
 				}
 				while (churnApprovals.size() < numberOfJoinRequests) {
-					churnApprovals.insert(rand() % numberOfShards);
+					churnApprovals.insert(randMod(numberOfShards));
 					nextNode->joining = true;
 					nextNode->alive = true;
 				}
@@ -338,7 +338,7 @@ namespace quantas {
 						if (!foundShards) {
 							int otherShard;
 							do {
-								otherShard = rand() % numberOfShards;
+								otherShard = randMod(numberOfShards);
 							} while (otherShard == shard);
 							// if the leader is in the other shard
 							if (shards.find(otherShard) != shards.end()) {

--- a/quantas/StableDataLinkPeer/StableDataLinkPeer.cpp
+++ b/quantas/StableDataLinkPeer/StableDataLinkPeer.cpp
@@ -53,7 +53,7 @@ namespace quantas {
 				Packet<StableDataLinkMessage> packet = popInStream();
 				long source = packet.sourceId();
 				StableDataLinkMessage message = packet.getMessage();
-				if (rand() % messageLossDen < messageLossNum) { // used for message loss
+				if (randMod(messageLossNum)) { // used for message loss
 					continue;
 				}
 				if (message.action == "ack") {

--- a/quantas/StableDataLinkPeer/StableDataLinkPeer.cpp
+++ b/quantas/StableDataLinkPeer/StableDataLinkPeer.cpp
@@ -53,7 +53,7 @@ namespace quantas {
 				Packet<StableDataLinkMessage> packet = popInStream();
 				long source = packet.sourceId();
 				StableDataLinkMessage message = packet.getMessage();
-				if (randMod(messageLossNum)) { // used for message loss
+				if (randMod(messageLossDen) < messageLossNum) { // used for message loss
 					continue;
 				}
 				if (message.action == "ack") {

--- a/quantas/Tests/randtest.cpp
+++ b/quantas/Tests/randtest.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <thread>
+#include <vector>
+#include <cassert>
+#include "../Common/Distribution.hpp"
+
+void getRandomInts(std::vector<int> &randomInts, int howMany)
+{
+    for (int i = 0; i < howMany; i++)
+    {
+        randomInts.push_back(quantas::uniformInt(0, 1 << 16));
+    }
+}
+
+int main()
+{
+    const int RandIntCount = 10;
+    const int ThreadCount = 10;
+
+    std::vector<std::vector<int>> results(ThreadCount);
+    std::vector<std::thread> threads(ThreadCount);
+    for (int j = 0; j < ThreadCount; j++)
+    {
+        threads[j] = std::thread(getRandomInts, std::ref(results[j]), RandIntCount);
+    }
+
+    for (auto &t : threads)
+    {
+        t.join();
+    }
+
+    for (int k = 0; k < RandIntCount; k++)
+    {
+        for (int threadIndex = 1; threadIndex < ThreadCount; threadIndex++)
+        {
+            assert(results[0][k] != results[threadIndex][k]);
+            std::cout << results[threadIndex][k] << " ";
+        }
+        std::cout << std::endl;
+    }
+
+    return 0;
+}

--- a/quantas/Tests/randtest.cpp
+++ b/quantas/Tests/randtest.cpp
@@ -29,14 +29,21 @@ int main()
         t.join();
     }
 
+    for (auto &vecForThread : results)
+    {
+        for (auto &numInVec : vecForThread)
+        {
+            std::cout << numInVec << " ";
+        }
+        std::cout << std::endl;
+    }
+
     for (int k = 0; k < RandIntCount; k++)
     {
         for (int threadIndex = 1; threadIndex < ThreadCount; threadIndex++)
         {
             assert(results[0][k] != results[threadIndex][k]);
-            std::cout << results[threadIndex][k] << " ";
         }
-        std::cout << std::endl;
     }
 
     return 0;

--- a/quantas/main.cpp
+++ b/quantas/main.cpp
@@ -28,8 +28,6 @@
 using nlohmann::json;
 
 int main(int argc, const char* argv[]) {
-
-   srand(time(nullptr));
    if (argc < 2) {
       std::cerr << "usage: " << argv[0] << " inputFileName "<< std::endl;
       return 1;


### PR DESCRIPTION
There are problems with the current implementation of random number generation in Quantas:

 - Multiple generators are used: rand(), quantas::RANDOM_GENERATOR, and std::mt19937 all make appearances, seeded from time() or std::random_device.
 - Those methods are not reliable: rand() needs to be seeded per-thread on Windows and isn't; random_device is not guaranteed to be unpredictable.

This pull request creates a thread-local random number generator (which is seeded with both the current time and the ID of the thread), adds convenience functions that are drop-in replacements for the strategies listed above, and drops them in. It also adds a test and clumsily staples it onto the test regime recently added to the makefile. Also, Distribution.cpp exists as a separate compilation unit now.

With g++ on Windows, the test produces this output with srand() and rand():

```
62509 36047 63046 12585 23300 23988 32632 23000 18536 22183 
62509 36047 63046 12585 23300 23988 32632 23000 18536 22183 
62509 36047 63046 12585 23300 23988 32632 23000 18536 22183
62509 36047 63046 12585 23300 23988 32632 23000 18536 22183
62509 36047 63046 12585 23300 23988 32632 23000 18536 22183
62509 36047 63046 12585 23300 23988 32632 23000 18536 22183
62509 36047 63046 12585 23300 23988 32632 23000 18536 22183
62509 36047 63046 12585 23300 23988 32632 23000 18536 22183
62509 36047 63046 12585 23300 23988 32632 23000 18536 22183
62509 36047 63046 12585 23300 23988 32632 23000 18536 22183
assertion "results[0][k] != results[threadIndex][k]" failed: file ".\randtest.cpp", line 46, function: int main()
      0 [main] a 1251 cygwin_exception::open_stackdumpfile: Dumping stack trace to a.exe.stackdump
```

And this with the new uniformInt function in the quantas namespace:

```
60388 22459 50077 21476 40989 44456 45446 36711 40739 29698 
58136 58964 16176 33016 6330 31253 57570 50138 52825 57811 
25637 44289 64658 22391 19655 35463 39033 5868 2943 50469
65502 53673 30648 46413 37710 40255 25367 31340 17574 56269
12570 35410 56554 22054 54543 28597 39706 45013 31438 24749
56560 51800 5307 14066 13518 47544 42724 43767 1735 8730
46757 45888 57187 30782 10919 19947 37639 40909 6727 22885
51145 1915 9041 41695 36516 27342 437 11502 49036 12788
29222 63397 1499 28660 63168 17350 31149 4163 46325 62981
57029 4663 63337 47685 55674 38833 55423 9439 42711 15549
```

So, that is better.